### PR TITLE
feat:$46-거래 완료 및 약속 목록 조회 기능 수정

### DIFF
--- a/src/main/java/io/k2c1/hereyougo/controller/AppointmentController.java
+++ b/src/main/java/io/k2c1/hereyougo/controller/AppointmentController.java
@@ -1,5 +1,8 @@
 package io.k2c1.hereyougo.controller;
 
+import io.k2c1.hereyougo.constant.SessionConst;
+import io.k2c1.hereyougo.domain.Appointment;
+import io.k2c1.hereyougo.domain.Member;
 import io.k2c1.hereyougo.domain.Post;
 import io.k2c1.hereyougo.dto.AppointmentForm;
 import io.k2c1.hereyougo.service.AppointmentService;
@@ -9,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @Controller
@@ -55,4 +60,16 @@ public class AppointmentController {
     public void completeAppointment(@PathVariable("id") Long appointmentId){
         appointmentService.completeAppointment(appointmentId);
     }
+
+    @GetMapping("/list")
+    public String getAppointments(@SessionAttribute(name = SessionConst.LOGIN_MEMBER, required = false) Member loginMember, Model model){
+        Long memberId = loginMember.getId();
+        List<Appointment> appointments = appointmentService.getAppointments(memberId);
+        model.addAttribute("member", loginMember);
+        model.addAttribute("member", loginMember);
+        model.addAttribute("appointments", appointments);
+        return "appointment/AppointmentList";
+    }
+
+
 }

--- a/src/main/java/io/k2c1/hereyougo/controller/AppointmentController.java
+++ b/src/main/java/io/k2c1/hereyougo/controller/AppointmentController.java
@@ -49,4 +49,10 @@ public class AppointmentController {
     public void cancelAppointmentStatus(@PathVariable("id") Long appointmentId){
         appointmentService.cancelAppointment(appointmentId);
     }
+
+    @ResponseBody
+    @PutMapping("/{id}/status/complete")
+    public void completeAppointment(@PathVariable("id") Long appointmentId){
+        appointmentService.completeAppointment(appointmentId);
+    }
 }

--- a/src/main/java/io/k2c1/hereyougo/controller/ChatController.java
+++ b/src/main/java/io/k2c1/hereyougo/controller/ChatController.java
@@ -74,7 +74,6 @@ public class ChatController {
         model.addAttribute("roomId", roomId);
         model.addAttribute("writerId", chatRoom.getWriterId());
         model.addAttribute("chatRoom", chatRoom);
-        model.addAttribute("loginMember", loginMember);
         model.addAttribute("post", post);
         model.addAttribute("chatList", chatList);
         model.addAttribute("member", loginMember);

--- a/src/main/java/io/k2c1/hereyougo/repository/AppointmentRepository.java
+++ b/src/main/java/io/k2c1/hereyougo/repository/AppointmentRepository.java
@@ -2,6 +2,7 @@ package io.k2c1.hereyougo.repository;
 
 import io.k2c1.hereyougo.domain.Appointment;
 import io.k2c1.hereyougo.domain.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +15,7 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long>
 {
     @Query(value = "SELECT distinct a FROM Appointment a INNER JOIN a.post p WHERE p.writer = :writer_id OR a.wanted = :member_id order by a.timestamp asc ")
     List<Appointment> getAppointments(@Param("writer_id") Member writer_id, @Param("member_id") Member member_id);
+
+    @Query("SELECT DISTINCT a FROM Appointment a INNER JOIN a.post p WHERE p.writer = :writer_id OR a.wanted = :member_id ORDER BY a.timestamp ASC")
+    List<Appointment> getAppointmentsLimit5(@Param("writer_id") Member writer_id, @Param("member_id") Member member_id,  Pageable pageable);
 }

--- a/src/main/java/io/k2c1/hereyougo/repository/AppointmentRepository.java
+++ b/src/main/java/io/k2c1/hereyougo/repository/AppointmentRepository.java
@@ -12,6 +12,6 @@ import java.util.List;
 @Repository
 public interface AppointmentRepository extends JpaRepository<Appointment, Long>
 {
-    @Query(value = "SELECT distinct a FROM Appointment a INNER JOIN a.post p WHERE p.writer = :writer_id OR a.wanted = :member_id")
+    @Query(value = "SELECT distinct a FROM Appointment a INNER JOIN a.post p WHERE p.writer = :writer_id OR a.wanted = :member_id order by a.timestamp asc ")
     List<Appointment> getAppointments(@Param("writer_id") Member writer_id, @Param("member_id") Member member_id);
 }

--- a/src/main/java/io/k2c1/hereyougo/repository/PostRepository.java
+++ b/src/main/java/io/k2c1/hereyougo/repository/PostRepository.java
@@ -2,18 +2,13 @@ package io.k2c1.hereyougo.repository;
 
 import io.k2c1.hereyougo.domain.Member;
 import io.k2c1.hereyougo.domain.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>
@@ -23,4 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long>
     @Modifying
     @Query("delete from Post p where p.writer = :writer ")
     void deleteByWriter(@Param("writer") Member member);
+
+    List<Post> findFirst10ByWriter_Id(Long memberId);
 }

--- a/src/main/java/io/k2c1/hereyougo/service/AppointmentService.java
+++ b/src/main/java/io/k2c1/hereyougo/service/AppointmentService.java
@@ -1,5 +1,6 @@
 package io.k2c1.hereyougo.service;
 
+import io.k2c1.hereyougo.constant.PostStatus;
 import io.k2c1.hereyougo.constant.Progress;
 import io.k2c1.hereyougo.domain.Appointment;
 import io.k2c1.hereyougo.domain.ChatRoom;
@@ -116,6 +117,10 @@ public class AppointmentService {
         post.minusReservationQuantity(completeQuantity);
         post.minusPostQuantity(completeQuantity);
         log.info("수량 적어진" + post.getReservationQuantity());
+
+        if(post.getQuantity() == 0){
+            post.setPostStatus(PostStatus.DONATING_DONE);
+        }
     }
 
 

--- a/src/main/java/io/k2c1/hereyougo/service/AppointmentService.java
+++ b/src/main/java/io/k2c1/hereyougo/service/AppointmentService.java
@@ -101,4 +101,22 @@ public class AppointmentService {
         post.minusReservationQuantity(cancelQuantity);
         log.info("수량 적어진" + post.getReservationQuantity());
     }
+
+    public void completeAppointment(Long appointmentId){
+        Appointment appointment = appointmentRepository.findById(appointmentId).get();
+        Long postId = appointment.getPost().getId();
+        Post post = postRepository.findById(postId).get();
+
+        appointment.setProgress(Progress.DONE);
+
+        int completeQuantity = appointment.getAppointmentQuantity();
+
+        log.info("포스트 수량" + post.getReservationQuantity());
+
+        post.minusReservationQuantity(completeQuantity);
+        post.minusPostQuantity(completeQuantity);
+        log.info("수량 적어진" + post.getReservationQuantity());
+    }
+
+
 }

--- a/src/main/java/io/k2c1/hereyougo/service/MemberService.java
+++ b/src/main/java/io/k2c1/hereyougo/service/MemberService.java
@@ -9,6 +9,9 @@ import io.k2c1.hereyougo.repository.FavoriteCategoryRepository;
 import io.k2c1.hereyougo.repository.MemberRepository;
 import io.k2c1.hereyougo.repository.PostRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,7 +93,7 @@ public class MemberService {
         Member member = findMember(memberId);
         myPageForm.setNickname(member.getNickname());
 
-        List<Post> posts = postRepository.findByWriter_Id(memberId);
+        List<Post> posts = postRepository.findFirst10ByWriter_Id(memberId);
         myPageForm.setPosts(posts);
 
         List<FavoriteCategory> favoriteCategories = favoriteCategoryRepository.findByMember_id(memberId);
@@ -98,7 +101,8 @@ public class MemberService {
 
 //        키워드 목록 Set하기
 //        약속 목록 Set하기
-        List<Appointment> appointments = appointmentRepository.getAppointments(member, member);
+        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.ASC, "timestamp");
+        List<Appointment> appointments = appointmentRepository.getAppointmentsLimit5(member, member,pageable);
         myPageForm.setAppointments(appointments);
 
         return myPageForm;

--- a/src/main/resources/static/css/member/mypage.css
+++ b/src/main/resources/static/css/member/mypage.css
@@ -40,7 +40,7 @@ body{
      display: grid;
      justify-content: center;
      align-items: center;
-     height: 100vh;
+     min-height: 100vh;
 }
 
 div#root {
@@ -147,4 +147,24 @@ a.addFavoriteBtn {
     font-family: gsans-light;
     font-weight: 600;
     text-align : center;
+    padding: 15px 0px;
+    vertical-align: middle;
+}
+
+td.appointment-title{
+    text-align: left;
+}
+
+td.appointment-title a{
+    color : #000,
+    text-decoration : none;
+}
+
+.appointment-nickname, .appointment-quantity, .appointment-progress{
+    text-align: center;
+}
+
+button.appointment-complete-btn, button.appointment-cancel-btn {
+    padding: 10px 8px;
+    font-size: 13px;
 }

--- a/src/main/resources/static/js/members/myPage.js
+++ b/src/main/resources/static/js/members/myPage.js
@@ -34,3 +34,19 @@ function cancelAppointment(appointmentId){
         });
     }
 }
+
+function completeAppointment(appointmentId){
+    var result = confirm("완료하시겠습니까?");
+
+    if(result){
+        var appointmentId = appointmentId
+
+        $.ajax({
+            url: "/appointments/"+appointmentId+ "/status/complete",
+            type: "PUT",
+        }).done(function (data){
+            alert('완료되었습니다')
+            location.reload();
+        });
+    }
+}

--- a/src/main/resources/templates/chat/chatting.html
+++ b/src/main/resources/templates/chat/chatting.html
@@ -33,7 +33,7 @@
                         <div class="input-group">
                             <input type="hidden" id="postId" th:value="${post.id}">
                             <input type="hidden" id="chatRoomId" th:value="${roomId}">
-                            <input type="hidden" id="memberId" th:value="${loggedMemberId}">
+                            <input type="hidden" id="memberId" th:value="${member.id}">
                             <input type="hidden" id="writerId" th:value="${writerId}">
                             <input type="text" placeholder="메시지를 입력하세요" id="message" autofocus class="form-control">
                             <div class="input-group-append">
@@ -130,12 +130,6 @@
                 showChatMessage(JSON.parse(chatMessage.body))
 
                 var length = $(".chatMessage-container").children().length;
-
-                if(length < 1){
-                    $(".chatMessage-container").append('<div class="chatMessage-empty"><div class="empty-message">메시지 내역이 없습니다 ✉</div></div>');
-                }else{
-                    $(".chatMessage-empty").hide();
-                }
             })
         })
     }
@@ -152,9 +146,10 @@
 
         console.log('채팅방 메시지 보내지는지')
         roomId = $("#chatRoomId").val()
-
+        memberId =  $("#memberId").val()
         var length = $(".chatMessage-empty").children().length;
 
+        console.log("로그인한 멤버 아이디" + memberId);
         let jsonOb={
             chatRoomId : $("#chatRoomId").val(),
             sender : $("#memberId").val(),

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -17,6 +17,7 @@
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" th:href="@{/members/mypage}">마이페이지</a></li>
                             <li><a class="dropdown-item" th:href="@{/posts/list}">작성글 목록</a></li>
+                            <li><a class="dropdown-item" th:href="@{/appointments/list}">약속 목록</a></li>
                             <li><a class="dropdown-item" th:href="@{/chatroom/roomList}">채팅 목록</a></li>
                         </ul>
                     </div>

--- a/src/main/resources/templates/members/myPage.html
+++ b/src/main/resources/templates/members/myPage.html
@@ -32,8 +32,8 @@
             <table class="table">
                 <thead>
                 <tr>
-                    <th scope="col"></th>
                     <th scope="col">거래명</th>
+                    <th scope="col">거래자명</th>
                     <th scope="col">거래수량</th>
                     <th scope="col">약속날짜</th>
                     <th scope="col">거래상태</th>
@@ -43,7 +43,12 @@
                 <tbody>
                 <tr th:each="appointment : ${mypage.appointments}">
                     <td><a th:href="@{/chat/{roomId}(roomId = ${appointment.chatRoom.id})}"><span th:text="${appointment.post.title}"></span></a></td>
-                    <td th:text="${appointment.wanted.nickname}" scope="row"></td>
+                    <th:block th:if="${appointment.wanted.id == member.id}">
+                        <td th:text="${appointment.post.writer.nickname}" scope="row"></td>
+                    </th:block>
+                    <th:block th:if="${appointment.wanted.id != member.id}">
+                        <td th:text="${appointment.wanted.nickname}" scope="row"></td>
+                    </th:block>
                     <td th:text="${appointment.appointmentQuantity}" scope="row"></td>
                     <!-- ${#dates.format(item.createDt, 'yyyy-MM-dd HH:mm:ss')}-->
                     <td th:text="${#temporals.format(appointment.timestamp,'yyyy-MM-dd')}"></td>
@@ -55,7 +60,7 @@
                     </th:block>
                     <th:block th:if="${appointment.progress.toString().equals('RESERVING')}">
                         <td>
-                            <button class="appointmentStatus styled" type="button" th:appointment=${appointment.id}  th:onclick="completeAppointment(this.getAttribute('appointment'))">전달 완료</button>
+                            <button  th:if="${appointment.wanted.id == member.id}" class="appointmentStatus styled" type="button" th:appointment=${appointment.id}  th:onclick="completeAppointment(this.getAttribute('appointment'))">전달 완료</button>
                             <button class="appointmentStatus styled" type="button" th:appointment=${appointment.id}  th:onclick="cancelAppointment(this.getAttribute('appointment'))">약속 취소</button>
                         </td>
                     </th:block>

--- a/src/main/resources/templates/members/myPage.html
+++ b/src/main/resources/templates/members/myPage.html
@@ -42,31 +42,32 @@
                 </thead>
                 <tbody>
                 <tr th:each="appointment : ${mypage.appointments}">
-                    <td><a th:href="@{/chat/{roomId}(roomId = ${appointment.chatRoom.id})}"><span th:text="${appointment.post.title}"></span></a></td>
+                    <td class="appointment-title"><a th:href="@{/chat/{roomId}(roomId = ${appointment.chatRoom.id})}"><span th:text="${appointment.post.title}"></span></a></td>
                     <th:block th:if="${appointment.wanted.id == member.id}">
                         <td th:text="${appointment.post.writer.nickname}" scope="row"></td>
                     </th:block>
                     <th:block th:if="${appointment.wanted.id != member.id}">
-                        <td th:text="${appointment.wanted.nickname}" scope="row"></td>
+                        <td class="appointment-nickname" th:text="${appointment.wanted.nickname}" scope="row"></td>
                     </th:block>
-                    <td th:text="${appointment.appointmentQuantity}" scope="row"></td>
+                    <td class="appointment-quantity" th:text="${appointment.appointmentQuantity}" scope="row"></td>
                     <!-- ${#dates.format(item.createDt, 'yyyy-MM-dd HH:mm:ss')}-->
                     <td th:text="${#temporals.format(appointment.timestamp,'yyyy-MM-dd')}"></td>
                     <th:block th:switch="${appointment.progress.toString()}">
-                        <td th:case="RESERVING" th:text="예약완료"></td>
-                        <td th:case="CANCEL" th:text="예약취소"></td>
-                        <td th:case="DONE" th:text="전달완료"></td>
-                        <td th:case="*" th:text="Unknown"></td> <!-- default case -->
+                        <td class="appointment-progress" th:case="RESERVING" th:text="예약완료"></td>
+                        <td class="appointment-progress" th:case="CANCEL" th:text="예약취소"></td>
+                        <td class="appointment-progress" th:case="DONE" th:text="전달완료"></td>
                     </th:block>
-                    <th:block th:if="${appointment.progress.toString().equals('RESERVING')}">
-                        <td>
-                            <button  th:if="${appointment.wanted.id == member.id}" class="appointmentStatus styled" type="button" th:appointment=${appointment.id}  th:onclick="completeAppointment(this.getAttribute('appointment'))">전달 완료</button>
-                            <button class="appointmentStatus styled" type="button" th:appointment=${appointment.id}  th:onclick="cancelAppointment(this.getAttribute('appointment'))">약속 취소</button>
-                        </td>
-                    </th:block>
+
+                    <td>
+                        <th:block th:if="${appointment.progress.toString().equals('RESERVING')}">
+                            <button class="appointment-complete-btn" th:if="${appointment.wanted.id == member.id}"  type="button" th:appointment=${appointment.id}  th:onclick="completeAppointment(this.getAttribute('appointment'))">전달 완료</button>
+                            <button class="appointment-cancel-btn styled" type="button" th:appointment=${appointment.id}  th:onclick="cancelAppointment(this.getAttribute('appointment'))">약속 취소</button>
+                        </th:block>
+                    </td>
                 </tr>
                 </tbody>
             </table>
+            <button class="appointment-list-btn" type="button"  th:onclick="|location.href='@{/appointments/list}'|">전체 약속 보기</button>
         </div>
 
         <div class="posts-container">
@@ -90,6 +91,7 @@
                 </tr>
                 </tbody>
             </table>
+            <button class="post-list-btn" type="button" th:onclick="|location.href='@{/posts/list}'|">전체 글 보기</button>
         </div><script th:inline="javascript" th:src="@{/js/members/myPage.js}"></script>
     </div><br><br>
 </div>


### PR DESCRIPTION
 **1. 거래 완료 기능**
- 포스트 수량과 포스트 예약 수량은 글  예약 수량 만큼 차감된다
- 예약 상태는 완료로 변경된다
- 글 품목 전달 완료 후 Post 수량이 0이 될 경우, Post 상태가  DONATING_DONE으로 변경

**2. 약속 목록 조회**
- 약속 목록에 거래자명 표시

**3.  마이페이지 글/약속 목록 최근글 5개 표시**
- Post, Appointment Repository에 최근 글 5개 표시하는 쿼리 작성
- 마이페이지 서비스에 글/약속 목록 저장하는 코드 수정

**4.** 약속 목록에서 해당 채팅방으로 이동 시 채팅 메시지 색 표시가 적용안되는 오류 해결
- 메시지를 전송할 경우, 메시지를 전송한 본인일 경우, 파란색으로 표시되는데 회색으로 표시되는 오류 발생